### PR TITLE
Add no-handler-update option to omit updating the handler on lambda

### DIFF
--- a/docs/update.md
+++ b/docs/update.md
@@ -16,6 +16,12 @@ claudia update {OPTIONS}
     * _Defaults to_: current directory
 *  `--config`:  (_optional_) Config file containing the resource names
     * _Defaults to_: claudia.json
+*  `--handler`:  (_optional_) Main function for Lambda to execute, as module.function
+    * _For example_: if it is in the main.js file and exported as router, this would be main.router
+*  `--no-handler-update`:  (_optional_) Do not update the handler in Lambda. This can be used in conjunction with `--handler`
+    when you want to validate a handler function name different from what is configured in Lambda. 
+    This is useful if additional layers wrap the handler (e.g., [Datadog](https://docs.datadoghq.com/serverless/installation/nodejs/?tab=custom)).
+    * _Defaults to_: updates handler if provided via `--handler` or ends in `'router'`
 *  `--timeout`:  (_optional_) The function execution time, in seconds, at which AWS Lambda should terminate the function
 *  `--runtime`:  (_optional_) Node.js runtime to use. For supported values, see
     http://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -793,7 +793,7 @@
     "events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw=="
     },
     "exit": {
       "version": "0.1.2",
@@ -1076,7 +1076,7 @@
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+      "integrity": "sha512-+kHj8HXArPfpPEKGLZ+kB5ONRTCiGQXo8RQYL0hH8t6pWXUBBK5KkkQmTNOwKK4LEsd0yTsgtjJVm4UBSZea4w=="
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -1395,7 +1395,7 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g=="
     },
     "readable-stream": {
       "version": "3.6.0",
@@ -1436,7 +1436,7 @@
     "sax": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
     },
     "seek-bzip": {
       "version": "1.0.6",
@@ -1672,7 +1672,7 @@
     "url": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -1681,7 +1681,7 @@
         "punycode": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+          "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
         }
       }
     },
@@ -1732,7 +1732,7 @@
     "xmlbuilder": {
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+      "integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/spec/update-spec.js
+++ b/spec/update-spec.js
@@ -667,7 +667,6 @@ describe('update', () => {
 				.then(done, done.fail);
 		});
 	});
-
 	describe('timeout option support', () => {
 		beforeEach(done => {
 			fsUtil.copy('spec/test-projects/hello-world', workingdir, true);

--- a/spec/update-spec.js
+++ b/spec/update-spec.js
@@ -624,6 +624,7 @@ describe('update', () => {
 			]);
 		}).then(done, done.fail);
 	});
+
 	describe('handler option support', () => {
 		beforeEach(done => {
 			fsUtil.copy('spec/test-projects/hello-world', workingdir, true);
@@ -656,7 +657,15 @@ describe('update', () => {
 			.then(configuration => expect(configuration.Handler).toEqual('main.handler'))
 			.then(done, done.fail);
 		});
-
+		it('does not update AWS handler name with --no-handler-update', done => {
+			fsUtil.copy('spec/test-projects/api-gw-echo', workingdir, true);
+			underTest({source: workingdir, version: 'new', handler: 'main.proxyRouter', 'handler-update': false})
+				.then(() => getLambdaConfiguration())
+				.then(configuration => expect(configuration.Handler).toEqual('main.handler'))// TODO: this may be old
+				.then(() => getLambdaConfiguration('new'))
+				.then(configuration => expect(configuration.Handler).toEqual('main.handler'))
+				.then(done, done.fail);
+		});
 	});
 
 	describe('timeout option support', () => {

--- a/src/commands/update.js
+++ b/src/commands/update.js
@@ -230,12 +230,13 @@ module.exports = function update(options, optionalLogger) {
 	.then(() => lambda.getFunctionConfiguration({FunctionName: lambdaConfig.name}).promise())
 	.then(result => {
 		functionConfig = result;
-		requiresHandlerUpdate = apiConfig && apiConfig.id && /\.router$/.test(functionConfig.Handler);
+		const explicitNoUpdateHandler = options['handler-update'] === false;
+		requiresHandlerUpdate = !explicitNoUpdateHandler && apiConfig && apiConfig.id && /\.router$/.test(functionConfig.Handler);
 		if (requiresHandlerUpdate) {
 			functionConfig.Handler = functionConfig.Handler.replace(/\.router$/, '.proxyRouter');
 		} else if (options.handler) {
 			functionConfig.Handler = options.handler;
-			requiresHandlerUpdate = true;
+			requiresHandlerUpdate = !explicitNoUpdateHandler;
 		}
 	})
 	.then(() => {

--- a/src/tasks/wait-until-not-pending.js
+++ b/src/tasks/wait-until-not-pending.js
@@ -5,10 +5,10 @@ module.exports = function waitUntilNotPending(lambda, functionName, timeout, ret
 		() => {
 			return lambda.getFunctionConfiguration({FunctionName: functionName}).promise()
 				.then(result => {
-					if (result.state === 'Failed') {
+					if (result.State === 'Failed') {
 						throw `Lambda resource update failed`;
 					}
-					if (result.state === 'Pending') {
+					if (result.State === 'Pending') {
 						throw 'Pending';
 					}
 					if (result.LastUpdateStatus === 'InProgress') {


### PR DESCRIPTION
With `--no-handler-update` this should pass in `handler-update: false` as an option to `update()` and it should then skip updating the handler in Lambda even when --handler is provided.

This also fixes the code that checks for the pending state as AWS returns the state with a capital "S".